### PR TITLE
Update session title

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -73,7 +73,7 @@ section.section
         .speakers_timetable_item
           | ビジネスモデルを設計する
         .speakers_timetable_item
-          | ユーザー理解（インサイトの発見）
+          | ユーザー理解（行動観察）
         .speakers_timetable_item
           | 良いUXをデザインする
         .speakers_timetable_item
@@ -81,7 +81,7 @@ section.section
         .speakers_timetable_item
           | PMの採用と育成
         .speakers_timetable_item
-          | 日本のプロダクトマネジメント普及の道のり、その先にあるものは何か？
+          | 日本のプロダクトマネージャーのあるべき姿とは
       .speakers_text
         | プロダクトマネジメントを様々な側面から切り取ったテーマに沿って、それぞれの領域のプロたちに登壇いただきます。
         | それ以外にも、ワールドカフェ形式のテーマトークやディープにプロダクトマネジメントを掘り下げるセッションなど、

--- a/source/schedule/index.html.slim
+++ b/source/schedule/index.html.slim
@@ -227,7 +227,7 @@ descriptipon: カンファレンスのタイムテーブルについて紹介し
                 = image_tag 'pmconf_ico.png', width: '100', height: '100'
               .scheduleTable_line_descriptions
                 .scheduleTable_line_title
-                  | ユーザー理解（インサイトの発見）
+                  | ユーザー理解（行動観察）
                 .scheduleTable_line_speaker
                   | 登壇者調整中
           .scheduleTable_line
@@ -337,7 +337,7 @@ descriptipon: カンファレンスのタイムテーブルについて紹介し
                 .scheduleTable_line_title
                   | ディープセッション
                   br
-                  |「日本のプロダクトマネジメント普及の道のり、その先にあるものは何か？」
+                  |「日本のプロダクトマネージャーのあるべき姿とは」
                 .scheduleTable_line_speaker
                   | 今年のテーマ：広げる、深める、日本のプロダクトマネジメント
           .scheduleTable_line


### PR DESCRIPTION
> セッションタイトルの修正案です。
> ・ユーザー理解（インサイトの発見）
> →「ユーザー理解（ユーザー観察）」or 「ユーザー理解（行動観察）」
> とか。インサイトの意味合い次第なのですが、データ分析した結果インサイトを発見した、という使い方もする用語なので、データ分析と対比する用語にしたほうがいいかも。
> 
> ・日本のプロダクトマネジメント普及の道のり、その先にあるものは何か？
> →「日本のプロダクトマネージャーのあるべき姿とは」
> ２日間を通してプロダクトマネジメントを構成する要素を分解して学びを得た。最後にそれらを振り返って統合するセッション、というイメージです。

「ユーザー理解（行動観察）」
「日本のプロダクトマネージャーのあるべき姿とは」